### PR TITLE
Fixed two dumb bugs that were preventing multiple controllers from wo…

### DIFF
--- a/Source/PSMove/Private/FPSMove.cpp
+++ b/Source/PSMove/Private/FPSMove.cpp
@@ -198,7 +198,7 @@ bool FPSMoveInternal::AcquirePSMove(int32 PlayerIndex, EControllerHand Hand, FPS
             //i.e. my_PSMoveComponent->DataContextPtr = &(my_FPSMoveSingleton.ControllerDataContexts[DataContextIndex])
             *OutDataContext = DataContext;
 
-            success= WorkerSingleton->AcquirePSMove(PlayerIndex, DataContext);
+			success = WorkerSingleton->AcquirePSMove(DataContextIndex, DataContext);
         }
     }
 
@@ -466,7 +466,7 @@ bool FPSMoveInputManager::GetControllerOrientationAndPosition(
     FRotator& OutOrientation, FVector& OutPosition) const
 {
     bool RetVal = false;
-    static int32 DataContextIndex= FPSMoveInternal::PlayerHandToDataContextIndex(PlayerIndex, DeviceHand);
+    int32 DataContextIndex= FPSMoveInternal::PlayerHandToDataContextIndex(PlayerIndex, DeviceHand);
     const FPSMoveDataContext *ControllerDataContext = PSMovePlugin->GetDataContextByIndex(DataContextIndex);
 
     if (ControllerDataContext != nullptr && ControllerDataContext->GetIsEnabled())


### PR DESCRIPTION
…rking
- Passing the PlayerIndex instead of the DataContextIndex to AcquirePSMove (this mapped left and right controller to the same context)
- Stored the DataContextIndex in a local static variable (typo?) on GetControllerOrientationAndPosition(), which causes all controllers to get the same position and orientation.
