### PR TITLE
Small build fix for MSVC 2015.

### DIFF
--- a/ThirdParty/psmoveapi/include/psmove_time.h
+++ b/ThirdParty/psmoveapi/include/psmove_time.h
@@ -40,10 +40,14 @@ extern "C" {
 #endif
 
 #ifdef _MSC_VER
+
+// timespec is defined in MSVC 2015
+#ifndef TIME_UTC
 struct timespec {               /* definition per POSIX.4 */
 	time_t          tv_sec;         /* seconds */
 	long            tv_nsec;        /* and nanoseconds */
 };
+#endif // TIME_UTC
 
 typedef int64_t __int64_t;
 #endif // _MSC_VER


### PR DESCRIPTION
I've still been using MSVC 2013 at work (turns out 2013 still works for UE4.10). When building in 2015 a new error showed up about timespec getting defined multiple times. I originally had to define the timespec class in psmove_time.h because wasn't defined in the MSVC C Runtime. A Google search turned up its msdn.microsoft.com article that states this is no longer the case:

https://msdn.microsoft.com/en-us/library/bb531344.aspx:

"timespec and TIME_UTC

The <time.h> header now defines the timespec type and the timespec_get function from the C11 Standard. In addition, the TIME_UTC macro, for use with the timespec_get function, is now defined. This is a breaking change for code that has a conflicting definition for any of these."

I added an extra check. If TIME_UTC is defined then we shouldn't be defining timespec. I verified that this compiles in both 2013 and 2015.
